### PR TITLE
disable squash button

### DIFF
--- a/src/content_scripts/index.js
+++ b/src/content_scripts/index.js
@@ -1,18 +1,19 @@
-function checkBranch(){
-    chrome.storage.sync.get(({branchesList:[]}), (data)=>{  
+function checkBranch() {
+    chrome.storage.sync.get(({ branchesList: [] }), (data) => {
         const targetBranch = document.querySelector("span.commit-ref span.css-truncate-target").innerText
-        if (data.branchesList.includes(targetBranch)){
-            const button = document.querySelector("button.js-merge-box-button-squash")
-            if (button){
-                button.disabled=true
-            }else{
-                setTimeout(checkBranch,125)
+        if (data.branchesList.includes(targetBranch)) {
+            const items = document.getElementsByClassName("btn-group-squash")
+            if (items.length > 0) {
+                for (let i = 0; i < items.length; i++) {
+                    items[i].disabled = true
+                }
+            } else {
+                setTimeout(checkBranch, 125)
             }
-        }    
+        }
     })
 }
 
-
-window.onload = function() {
+window.onload = function () {
     setTimeout(checkBranch, 125)
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,6 +20,6 @@
     "content_scripts": [{
       "matches": ["*://github.com/*/pull/*"],
       "js": ["content_scripts/index.js"],
-      "run_at":"document_idle"
+      "run_at":"document_end"
     }]
   }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Github Squash Merge Preventer",
     "description": "A Chrome Extension to prevent squash merging for certain branches",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "author": "Tim Stevens",
     "icons": {
       "16": "icons/icon16.png",
@@ -10,9 +10,9 @@
       "48": "icons/icon48.png",
       "128": "icons/icon128.png"
     },
-    "omnibox": { 
-      "keyword" : "@@" 
-    },    
+    "omnibox": {
+      "keyword" : "@@"
+    },
     "permissions": [
       "storage"
     ],
@@ -23,4 +23,3 @@
       "run_at":"document_idle"
     }]
   }
-  


### PR DESCRIPTION
This Chrome extension is very nice.

For example, on Github, if I do a Squash Merge on another branch, the Squash Merge Button is selected by default the next time. Then the button could be pressed in the original specification.

I have changed it to disable the Squash Merge Button itself.

<img width="923" alt="image" src="https://github.com/san1t1/github-squash-merge-preventer-chrome-extension/assets/23309/050c7a18-32ff-41c7-8577-ed27972206f1">

Please check the operation.

Thank you very much for your really good idea.