### PR TITLE
fix: disable merge button if squash is already selected

### DIFF
--- a/src/content_scripts/index.js
+++ b/src/content_scripts/index.js
@@ -1,18 +1,21 @@
-function checkBranch(){
-    chrome.storage.sync.get(({branchesList:[]}), (data)=>{  
-        const targetBranch = document.querySelector("span.commit-ref span.css-truncate-target").innerText
-        if (data.branchesList.includes(targetBranch)){
-            const button = document.querySelector("button.js-merge-box-button-squash")
-            if (button){
-                button.disabled=true
-            }else{
-                setTimeout(checkBranch,125)
+function checkBranch() {
+    chrome.storage.sync.get(({ branchesList: [] }), (data) => {  
+        const targetBranch = document.querySelector("span.commit-ref span.css-truncate-target").innerText;
+        if (data.branchesList.includes(targetBranch)) {
+            const selectItem = document.querySelector("button.js-merge-box-button-squash");
+            const mergeButton = document.querySelector("button.btn-group-squash");
+
+            if (selectItem && mergeButton) {
+                selectItem.disabled = true;
+                mergeButton.disabled = true;
+            } else {
+                setTimeout(checkBranch, 125);
             }
         }    
-    })
+    });
 }
 
 
 window.onload = function() {
-    setTimeout(checkBranch, 125)
+    setTimeout(checkBranch, 125);
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Github Squash Merge Preventer",
     "description": "A Chrome Extension to prevent squash merging for certain branches",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "author": "Tim Stevens",
     "icons": {
       "16": "icons/icon16.png",
@@ -10,9 +10,9 @@
       "48": "icons/icon48.png",
       "128": "icons/icon128.png"
     },
-    "omnibox": { 
-      "keyword" : "@@" 
-    },    
+    "omnibox": {
+      "keyword" : "@@"
+    },
     "permissions": [
       "storage"
     ],
@@ -23,4 +23,4 @@
       "run_at":"document_idle"
     }]
   }
-  
+ 


### PR DESCRIPTION
In GitHub, if you previously merged a PR using a squash merge, it will be selected by default the next time you merge a PR. In that case, this plugin wasn't working because you could still click "Squash and merge". This PR additionally disables that button. Screenshots below:
![Screenshot 2024-04-04 at 3 20 32 PM](https://github.com/san1t1/github-squash-merge-preventer-chrome-extension/assets/20236942/17607314-7d1d-4eae-b9f0-031fa3f4a3fc)
![Screenshot 2024-04-04 at 3 20 42 PM](https://github.com/san1t1/github-squash-merge-preventer-chrome-extension/assets/20236942/980f5da5-ff1f-428a-94ef-a16aa9e49e52)
